### PR TITLE
make the buffer size configurable

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -32,6 +32,11 @@ type Config struct {
 
 	// LogOutput is used to control the log destination
 	LogOutput io.Writer
+
+	// ReadBufSize controls the size of the read buffer.
+	//
+	// Set to 0 to disable it.
+	ReadBufSize int
 }
 
 // DefaultConfig is used to return a default configuration
@@ -43,6 +48,7 @@ func DefaultConfig() *Config {
 		ConnectionWriteTimeout: 10 * time.Second,
 		MaxStreamWindowSize:    initialStreamWindow,
 		LogOutput:              os.Stderr,
+		ReadBufSize:            4096,
 	}
 }
 
@@ -70,7 +76,7 @@ func Server(conn io.ReadWriteCloser, config *Config) (*Session, error) {
 	if err := VerifyConfig(config); err != nil {
 		return nil, err
 	}
-	return newSession(config, conn, false), nil
+	return newSession(config, conn, false, config.ReadBufSize), nil
 }
 
 // Client is used to initialize a new client-side connection.
@@ -83,5 +89,5 @@ func Client(conn io.ReadWriteCloser, config *Config) (*Session, error) {
 	if err := VerifyConfig(config); err != nil {
 		return nil, err
 	}
-	return newSession(config, conn, true), nil
+	return newSession(config, conn, true, config.ReadBufSize), nil
 }

--- a/session.go
+++ b/session.go
@@ -38,8 +38,8 @@ type Session struct {
 	// conn is the underlying connection
 	conn io.ReadWriteCloser
 
-	// bufRead is a buffered reader
-	bufRead *bufio.Reader
+	// reader is a buffered reader
+	reader io.Reader
 
 	// pings is used to track inflight pings
 	pings    map[uint32]chan struct{}
@@ -85,12 +85,16 @@ type sendReady struct {
 }
 
 // newSession is used to construct a new session
-func newSession(config *Config, conn io.ReadWriteCloser, client bool) *Session {
+func newSession(config *Config, conn io.ReadWriteCloser, client bool, readBuf int) *Session {
+	var reader io.Reader = conn
+	if readBuf > 0 {
+		reader = bufio.NewReaderSize(reader, readBuf)
+	}
 	s := &Session{
 		config:     config,
 		logger:     log.New(config.LogOutput, "", log.LstdFlags),
 		conn:       conn,
-		bufRead:    bufio.NewReader(conn),
+		reader:     reader,
 		pings:      make(map[uint32]chan struct{}),
 		streams:    make(map[uint32]*Stream),
 		inflight:   make(map[uint32]struct{}),
@@ -448,7 +452,7 @@ func (s *Session) recvLoop() error {
 	hdr := header(make([]byte, headerSize))
 	for {
 		// Read the header
-		if _, err := io.ReadFull(s.bufRead, hdr); err != nil {
+		if _, err := io.ReadFull(s.reader, hdr); err != nil {
 			if err != io.EOF && !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "reset by peer") {
 				s.logger.Printf("[ERR] yamux: Failed to read header: %v", err)
 			}
@@ -493,7 +497,7 @@ func (s *Session) handleStreamMessage(hdr header) error {
 		// Drain any data on the wire
 		if hdr.MsgType() == typeData && hdr.Length() > 0 {
 			s.logger.Printf("[WARN] yamux: Discarding data for stream: %d", id)
-			if _, err := io.CopyN(ioutil.Discard, s.bufRead, int64(hdr.Length())); err != nil {
+			if _, err := io.CopyN(ioutil.Discard, s.reader, int64(hdr.Length())); err != nil {
 				s.logger.Printf("[ERR] yamux: Failed to discard data: %v", err)
 				return nil
 			}
@@ -515,7 +519,7 @@ func (s *Session) handleStreamMessage(hdr header) error {
 	}
 
 	// Read the new data
-	if err := stream.readData(hdr, flags, s.bufRead); err != nil {
+	if err := stream.readData(hdr, flags, s.reader); err != nil {
 		if sendErr := s.sendNoWait(s.goAway(goAwayProtoErr)); sendErr != nil {
 			s.logger.Printf("[WARN] yamux: failed to send go away: %v", sendErr)
 		}

--- a/stream.go
+++ b/stream.go
@@ -212,7 +212,6 @@ WAIT:
 	case <-timeout:
 		return 0, ErrTimeout
 	}
-	return 0, nil
 }
 
 // sendFlags determines any flags that are appropriate


### PR DESCRIPTION
We want to disable read buffering in go-ipfs as we do read buffering at a lower layer.