### PR TITLE
Yamux: handle IO write timeouts gracefully

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -1469,17 +1469,12 @@ func TestResetAfterTimeout(t *testing.T) {
 	if s, err = sess.OpenStream(); err != nil {
 		t.Fatal(err)
 	}
-
 	if s.Session().IsClosed() {
 		t.Error("expected session to be open")
 	}
-
-	n, err := s.Write(make([]byte, 1024*1024))
-
-	if err == nil || !strings.Contains(err.Error(), "timeout") {
+	if n, err := s.Write(make([]byte, 1024*1024)); err == nil || !strings.Contains(err.Error(), "timeout") {
 		t.Errorf("expected write to timeout, written bytes: %d, err: %v", n, err)
 	}
-
 	if !s.Session().IsClosed() {
 		t.Error("expected session to be closed following the timeout")
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -1484,9 +1484,6 @@ func TestResetAfterTimeout(t *testing.T) {
 		t.Error("expected session to be closed following the timeout")
 	}
 
-	// try to send another message.
-	n, err = s.Write(make([]byte, 1024*1024))
-
 	if err = s.Reset(); err == nil {
 		t.Error("expected stream reset to fail")
 	} else if !strings.Contains(err.Error(), "session shutdown") {


### PR DESCRIPTION
This PR introduces proper write timeout handling.

Prior to this contribution, Yamux would perform all writes to the underlying connection through `conn.Write()` without setting deadlines. Hence the caller would receive a timeout but the underlying write would not be cancelled, causing issues like the data race reported in https://github.com/libp2p/go-libp2p/issues/396.

This PR now sets write deadlines with `conn.SetWriteDeadline()` if the underlying IO is a `net.Conn`. It also introduces a "yielding" `io.Reader` as an attempt to cancel expired writes on blocking IO.

Whenever a partially-completed write expires, we shut down the entire session as it is now corrupted and Yamux has no recovery strategy for this. An exception is blocking IO; we can't shut down the session when the expiry is detected, because doing so would be non-deterministic.

This PR also introduces a test case for https://github.com/libp2p/go-libp2p/issues/396.

Note: when a write is cancelled with 0 bytes written, we do not shut down the underlying session. Ideally we'd add a `SessionClosed` field on `YamuxError` to convey when a connection is closed, but I didn't want to change much. Clients can always call `session.IsClosed()` after receiving the error to check the status.