### PR TITLE
Track IO write status, and selectively terminate session on timeout

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -1413,7 +1413,7 @@ func TestStreamResetRead(t *testing.T) {
 
 func TestLotsOfWritesWithStreamDeadline(t *testing.T) {
 	config := testConf()
-	config.ConnectionWriteTimeout = 5 * time.Minute
+	config.EnableKeepAlive = false
 
 	client, server := testClientServerConfig(config)
 	defer client.Close()
@@ -1421,22 +1421,38 @@ func TestLotsOfWritesWithStreamDeadline(t *testing.T) {
 
 	waitCh := make(chan struct{})
 	doneCh := make(chan struct{})
+
+	// Server side accepts two streams. The first one is the clogger.
 	go func() {
-		stream, err := server.AcceptStream()
+		_, err := server.AcceptStream()
 		if err != nil {
 			t.Error(err)
 		}
 
+		stream2, err := server.AcceptStream()
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Wait until all writes have timed out on the client.
 		<-waitCh
 
-		stream.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
-		if b, err := ioutil.ReadAll(stream); len(b) != 0 || err != ErrTimeout {
+		// stream2 should've received no messages, as they all expired in the buffer.
+		stream2.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+		if b, err := ioutil.ReadAll(stream2); len(b) != 0 || err != ErrTimeout {
 			t.Errorf("writes from the client should've expired; got: %v, bytes: %v", err, b)
 		}
 		doneCh <- struct{}{}
 	}()
 
-	stream, err := client.OpenStream()
+	// stream1 is the clogger.
+	stream1, err := client.OpenStream()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// all writes on stream2 will time out.
+	stream2, err := client.OpenStream()
 	if err != nil {
 		t.Error(err)
 	}
@@ -1444,95 +1460,34 @@ func TestLotsOfWritesWithStreamDeadline(t *testing.T) {
 	clientConn := client.conn.(*pipeConn)
 	clientConn.writeBlocker.Lock()
 
-	// enough to saturate the sendCh buffer
+	// Send a clogging write on stream1.
+	go func() {
+		stream1.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		stream1.Write([]byte{100})
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	// Send 100 writes on stream2.
 	var wg sync.WaitGroup
 	wg.Add(100)
 	for i := 0; i < 100; i++ {
 		go func() {
 			defer wg.Done()
-			stream.SetWriteDeadline(time.Now().Add(500 * time.Millisecond))
-			n, err := stream.Write([]byte{byte(i)})
+			stream2.SetWriteDeadline(time.Now().Add(100 * time.Millisecond))
+			n, err := stream2.Write([]byte{byte(i)})
+
 			if err != ErrTimeout || n != 0 {
 				t.Errorf("expected stream timeout error, got: %v, n: %d", err, n)
 			}
 		}()
 	}
+
+	// All writes completed and timed out; notify the server.
 	wg.Wait()
-
 	waitCh <- struct{}{}
+
 	<-doneCh
-}
-
-func TestConnTimeoutZeroWrittenBytesKeepsSessionOpen(t *testing.T) {
-	config := testConf()
-	// 8mb; we want the yamux window size to be big so that we're stalled by TCP's congestion control, not by yamux
-	// thus causing a connection timeout
-	config.MaxStreamWindowSize = 8 * 1024 * 1024
-	config.ConnectionWriteTimeout = 1 * time.Second
-	config.EnableKeepAlive = false
-
-	l, err := net.ListenTCP("tcp", nil)
-	if err != nil {
-		t.Error(err)
-	}
-
-	defer l.Close()
-	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	defer wg.Done()
-
-	bufCh := make(chan struct{})
-
-	// Server-side: a ghost socket that accepts connections and sets a tiny read buffer,
-	// forcing TCP congestion control to stall the window.
-	go func() {
-		if conn, err := l.AcceptTCP(); err != nil {
-			t.Fatal(err)
-		} else {
-			if err = conn.SetReadBuffer(1); err != nil {
-				t.Fatal(err)
-			}
-			bufCh <- struct{}{}
-			wg.Wait()
-		}
-	}()
-
-	var addr *net.TCPAddr
-	var conn *net.TCPConn
-	var sess *Session
-	var s *Stream
-
-	// Client-side: set a tiny write buffer to force the application (yamux) to wait.
-	if addr, err = net.ResolveTCPAddr("tcp", l.Addr().String()); err != nil {
-		t.Fatal(err)
-	}
-	if conn, err = net.DialTCP("tcp", nil, addr); err != nil {
-		t.Fatal(err)
-	}
-	if err = conn.SetWriteBuffer(1); err != nil {
-		t.Fatal(err)
-	}
-
-	<-bufCh
-
-	if sess, err = Client(conn, config); err != nil {
-		t.Fatal(err)
-	}
-	if s, err = sess.OpenStream(); err != nil {
-		t.Fatal(err)
-	}
-	if s.Session().IsClosed() {
-		t.Error("expected session to be open")
-	}
-	if n, err := s.Write(make([]byte, 1024*1024)); err == nil || !strings.Contains(err.Error(), "timeout") {
-		t.Errorf("expected write to timeout, written bytes: %d, err: %v", n, err)
-	}
-	if s.Session().IsClosed() {
-		t.Error("expected session to be open")
-	}
-	if s.state == streamEstablished {
-		t.Error("expected session state to be 'streamEstablished'")
-	}
 }
 
 func TestConnTimeoutPartialWriteClosesConnection(t *testing.T) {
@@ -1547,13 +1502,9 @@ func TestConnTimeoutPartialWriteClosesConnection(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
 	defer l.Close()
-	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	defer wg.Done()
 
-	bufCh := make(chan struct{})
+	bufferSetCh := make(chan struct{})
 
 	// Server-side: a socket that reads 100 bytes, and then stalls, i.e. perceived as a partial write from the sender.
 	go func() {
@@ -1565,7 +1516,7 @@ func TestConnTimeoutPartialWriteClosesConnection(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		bufCh <- struct{}{}
+		bufferSetCh <- struct{}{}
 
 		buf := make([]byte, 100)
 		total := 0
@@ -1576,8 +1527,6 @@ func TestConnTimeoutPartialWriteClosesConnection(t *testing.T) {
 				total += n
 			}
 		}
-
-		wg.Wait()
 	}()
 
 	var addr *net.TCPAddr
@@ -1596,7 +1545,7 @@ func TestConnTimeoutPartialWriteClosesConnection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	<-bufCh
+	<-bufferSetCh
 
 	if sess, err = Client(conn, config); err != nil {
 		t.Fatal(err)

--- a/stream.go
+++ b/stream.go
@@ -2,6 +2,7 @@ package yamux
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"

--- a/stream.go
+++ b/stream.go
@@ -2,7 +2,6 @@ package yamux
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"


### PR DESCRIPTION
Simplified implementation of #10.