### PR TITLE
[RFC] Proof of concept for peer-to-peer muxing

### DIFF
--- a/const.go
+++ b/const.go
@@ -63,7 +63,7 @@ var (
 
 const (
 	// protoVersion is the only version we support
-	protoVersion uint8 = 0
+	protoVersion uint8 = 1
 )
 
 const (
@@ -149,6 +149,10 @@ func (h header) StreamID() uint32 {
 
 func (h header) Length() uint32 {
 	return binary.BigEndian.Uint32(h[8:12])
+}
+
+func (h header) TranslateID() {
+	binary.BigEndian.PutUint32(h[4:8], translateID(h.StreamID()))
 }
 
 func (h header) String() string {

--- a/const_test.go
+++ b/const_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestConst(t *testing.T) {
-	if protoVersion != 0 {
+	if protoVersion != 1 {
 		t.Fatalf("bad: %v", protoVersion)
 	}
 

--- a/mux.go
+++ b/mux.go
@@ -66,28 +66,12 @@ func VerifyConfig(config *Config) error {
 	return nil
 }
 
-// Server is used to initialize a new server-side connection.
-// There must be at most one server-side connection. If a nil config is
-// provided, the DefaultConfiguration will be used.
-func Server(conn io.ReadWriteCloser, config *Config) (*Session, error) {
+func NewSession(conn io.ReadWriteCloser, config *Config) (*Session, error) {
 	if config == nil {
 		config = DefaultConfig()
 	}
 	if err := VerifyConfig(config); err != nil {
 		return nil, err
 	}
-	return newSession(config, conn, false, config.ReadBufSize), nil
-}
-
-// Client is used to initialize a new client-side connection.
-// There must be at most one client-side connection.
-func Client(conn io.ReadWriteCloser, config *Config) (*Session, error) {
-	if config == nil {
-		config = DefaultConfig()
-	}
-
-	if err := VerifyConfig(config); err != nil {
-		return nil, err
-	}
-	return newSession(config, conn, true, config.ReadBufSize), nil
+	return newSession(config, conn, config.ReadBufSize), nil
 }


### PR DESCRIPTION
This is a proof of concept to make yamux more p2p friendly, eliminating the "client/server" paradigm through the use of a simple bit mask. I'm not really sure how we can move forward with this, since it's a breaking change and nothing about the implementation is geared towards backwards compatibility (though it could be shoe-horned). Just wanted to sketch it out to see if it's something we want to pursue further.