### PR TITLE
fix panic when initializing a stream on shutdown

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -314,6 +314,11 @@ func (s *Stream) sendReset() error {
 func (s *Stream) Reset() error {
 	s.stateLock.Lock()
 	switch s.state {
+	case streamInit:
+		// No need to send anything.
+		s.state = streamReset
+		s.stateLock.Unlock()
+		return nil
 	case streamClosed, streamReset:
 		s.stateLock.Unlock()
 		return nil
@@ -337,12 +342,7 @@ func (s *Stream) Close() error {
 	closeStream := false
 	s.stateLock.Lock()
 	switch s.state {
-	// Opened means we need to signal a close
-	case streamSYNSent:
-		fallthrough
-	case streamSYNReceived:
-		fallthrough
-	case streamEstablished:
+	case streamInit, streamSYNSent, streamSYNReceived, streamEstablished:
 		s.state = streamLocalClose
 		goto SEND_CLOSE
 

--- a/stream.go
+++ b/stream.go
@@ -243,13 +243,6 @@ func (s *Stream) sendWindowUpdate() error {
 	s.controlHdrLock.Lock()
 	defer s.controlHdrLock.Unlock()
 
-	select {
-	case <-s.session.shutdownCh:
-		// short circuit as we're shutting down
-		return nil
-	default:
-	}
-
 	// Determine the delta update
 	max := s.session.config.MaxStreamWindowSize
 	s.recvLock.Lock()
@@ -281,13 +274,6 @@ func (s *Stream) sendClose() error {
 	s.controlHdrLock.Lock()
 	defer s.controlHdrLock.Unlock()
 
-	select {
-	case <-s.session.shutdownCh:
-		// short circuit as we're shutting down
-		return nil
-	default:
-	}
-
 	flags := s.sendFlags()
 	flags |= flagFIN
 	s.controlHdr.encode(typeWindowUpdate, flags, s.id, 0)
@@ -298,13 +284,6 @@ func (s *Stream) sendClose() error {
 func (s *Stream) sendReset() error {
 	s.controlHdrLock.Lock()
 	defer s.controlHdrLock.Unlock()
-
-	select {
-	case <-s.session.shutdownCh:
-		// short circuit as we're shutting down
-		return nil
-	default:
-	}
 
 	s.controlHdr.encode(typeWindowUpdate, flagRST, s.id, 0)
 	return s.session.waitForSendErr(s.controlHdr, nil, s.controlErr, nil)


### PR DESCRIPTION
When initializing a stream on shutdown, we could panic because we tried to reset
the stream while it was in the init state.

1. Fix this: Handle the init state where appropriate.
2. Move the shutdown short-circuits inwards to make sure we catch all
cases (that we care about).