### PR TITLE
correctly handle deadlines

### DIFF
--- a/deadline.go
+++ b/deadline.go
@@ -1,0 +1,62 @@
+package yamux
+
+import (
+	"sync"
+	"time"
+)
+
+type deadline struct {
+	C     <-chan time.Time
+	timer *time.Timer
+	mu    sync.Mutex
+}
+
+func newDeadline() *deadline {
+	d := new(deadline)
+	d.timer = time.NewTimer(0)
+	d.C = d.timer.C
+	d.set(time.Time{})
+	return d
+}
+
+// setExpired forces the deadline to expire now.
+func (d *deadline) setExpired() {
+	d.mu.Lock()
+	if d.timer != nil {
+		d.timer.Reset(0)
+	}
+	d.mu.Unlock()
+}
+
+// set sets the deadline.
+func (d *deadline) set(t time.Time) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.timer == nil {
+		return ErrStreamClosed
+	}
+	d.timer.Stop()
+	select {
+	case <-d.timer.C:
+	default:
+	}
+	if !t.IsZero() {
+		// negative timeout triggers immediately.
+		d.timer.Reset(time.Until(t))
+	}
+	return nil
+}
+
+func (d *deadline) Close() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.timer == nil {
+		return
+	}
+	d.timer.Stop()
+	select {
+	case <-d.timer.C:
+	default:
+	}
+	d.timer = nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/whyrusleeping/yamux
+
+go 1.12
+
+require github.com/libp2p/go-buffer-pool v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/libp2p/go-buffer-pool v0.0.1 h1:9Rrn/H46cXjaA2HQ5Y8lyhOS1NhTkZ4yuEs2r3Eechg=
+github.com/libp2p/go-buffer-pool v0.0.1/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg0a8KiIvDp3TzQ=


### PR DESCRIPTION
* Deadlines now interrupt reads/writes and can be modified concurrently.
* We now only need to read the time once when _setting_ the deadline instead of when using it.