### PR TITLE
Make deadlines interrupt and coalesce writes

### DIFF
--- a/LICENSE-BSD
+++ b/LICENSE-BSD
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/const.go
+++ b/const.go
@@ -115,6 +115,8 @@ const (
 const (
 	// initialStreamWindow is the initial stream window size
 	initialStreamWindow uint32 = 256 * 1024
+
+	maxMessageSize = 16 * 1024 // 16 KiB per write max.
 )
 
 const (

--- a/const.go
+++ b/const.go
@@ -6,59 +6,68 @@ import (
 )
 
 type YamuxError struct {
-	msg string
+	msg                string
+	timeout, temporary bool
 }
 
 func (ye YamuxError) Error() string {
 	return ye.msg
 }
 
+func (ye YamuxError) Timeout() bool {
+	return ye.timeout
+}
+
+func (ye YamuxError) Temporary() bool {
+	return ye.temporary
+}
+
 var (
 	// ErrInvalidVersion means we received a frame with an
 	// invalid version
-	ErrInvalidVersion = &YamuxError{"invalid protocol version"}
+	ErrInvalidVersion = &YamuxError{msg: "invalid protocol version"}
 
 	// ErrInvalidMsgType means we received a frame with an
 	// invalid message type
-	ErrInvalidMsgType = &YamuxError{"invalid msg type"}
+	ErrInvalidMsgType = &YamuxError{msg: "invalid msg type"}
 
 	// ErrSessionShutdown is used if there is a shutdown during
 	// an operation
-	ErrSessionShutdown = &YamuxError{"session shutdown"}
+	ErrSessionShutdown = &YamuxError{msg: "session shutdown"}
 
 	// ErrStreamsExhausted is returned if we have no more
 	// stream ids to issue
-	ErrStreamsExhausted = &YamuxError{"streams exhausted"}
+	ErrStreamsExhausted = &YamuxError{msg: "streams exhausted"}
 
 	// ErrDuplicateStream is used if a duplicate stream is
 	// opened inbound
-	ErrDuplicateStream = &YamuxError{"duplicate stream initiated"}
+	ErrDuplicateStream = &YamuxError{msg: "duplicate stream initiated"}
 
 	// ErrReceiveWindowExceeded indicates the window was exceeded
-	ErrRecvWindowExceeded = &YamuxError{"recv window exceeded"}
+	ErrRecvWindowExceeded = &YamuxError{msg: "recv window exceeded"}
 
 	// ErrTimeout is used when we reach an IO deadline
-	ErrTimeout = &YamuxError{"i/o deadline reached"}
+	ErrTimeout = &YamuxError{msg: "i/o deadline reached", timeout: true, temporary: true}
 
 	// ErrStreamClosed is returned when using a closed stream
-	ErrStreamClosed = &YamuxError{"stream closed"}
+	ErrStreamClosed = &YamuxError{msg: "stream closed"}
 
 	// ErrUnexpectedFlag is set when we get an unexpected flag
-	ErrUnexpectedFlag = &YamuxError{"unexpected flag"}
+	ErrUnexpectedFlag = &YamuxError{msg: "unexpected flag"}
 
 	// ErrRemoteGoAway is used when we get a go away from the other side
-	ErrRemoteGoAway = &YamuxError{"remote end is not accepting connections"}
+	ErrRemoteGoAway = &YamuxError{msg: "remote end is not accepting connections"}
 
 	// ErrConnectionReset is sent if a stream is reset. This can happen
 	// if the backlog is exceeded, or if there was a remote GoAway.
-	ErrConnectionReset = &YamuxError{"stream reset"}
+	ErrConnectionReset = &YamuxError{msg: "stream reset"}
 
 	// ErrConnectionWriteTimeout indicates that we hit the "safety valve"
 	// timeout writing to the underlying stream connection.
-	ErrConnectionWriteTimeout = &YamuxError{"connection write timeout"}
+	ErrConnectionWriteTimeout = &YamuxError{msg: "connection write timeout", timeout: true}
 
 	// ErrKeepAliveTimeout is sent if a missed keepalive caused the stream close
-	ErrKeepAliveTimeout = &YamuxError{"keepalive timeout"}
+	ErrKeepAliveTimeout = &YamuxError{msg: "keepalive timeout", timeout: true}
 )
 
 const (

--- a/const.go
+++ b/const.go
@@ -138,7 +138,7 @@ const (
 		sizeOfStreamID + sizeOfLength
 )
 
-type header []byte
+type header [headerSize]byte
 
 func (h header) Version() uint8 {
 	return h[0]
@@ -165,10 +165,12 @@ func (h header) String() string {
 		h.Version(), h.MsgType(), h.Flags(), h.StreamID(), h.Length())
 }
 
-func (h header) encode(msgType uint8, flags uint16, streamID uint32, length uint32) {
+func encode(msgType uint8, flags uint16, streamID uint32, length uint32) header {
+	var h header
 	h[0] = protoVersion
 	h[1] = msgType
 	binary.BigEndian.PutUint16(h[2:4], flags)
 	binary.BigEndian.PutUint32(h[4:8], streamID)
 	binary.BigEndian.PutUint32(h[8:12], length)
+	return h
 }

--- a/const_test.go
+++ b/const_test.go
@@ -51,8 +51,7 @@ func TestConst(t *testing.T) {
 }
 
 func TestEncodeDecode(t *testing.T) {
-	hdr := header(make([]byte, headerSize))
-	hdr.encode(typeWindowUpdate, flagACK|flagRST, 1234, 4321)
+	hdr := encode(typeWindowUpdate, flagACK|flagRST, 1234, 4321)
 
 	if hdr.Version() != protoVersion {
 		t.Fatalf("bad: %v", hdr)

--- a/deadline.go
+++ b/deadline.go
@@ -1,0 +1,80 @@
+// Copied from the go standard library.
+//
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE-BSD file.
+
+package yamux
+
+import (
+	"sync"
+	"time"
+)
+
+// pipeDeadline is an abstraction for handling timeouts.
+type pipeDeadline struct {
+	mu     sync.Mutex // Guards timer and cancel
+	timer  *time.Timer
+	cancel chan struct{} // Must be non-nil
+}
+
+func makePipeDeadline() pipeDeadline {
+	return pipeDeadline{cancel: make(chan struct{})}
+}
+
+// set sets the point in time when the deadline will time out.
+// A timeout event is signaled by closing the channel returned by waiter.
+// Once a timeout has occurred, the deadline can be refreshed by specifying a
+// t value in the future.
+//
+// A zero value for t prevents timeout.
+func (d *pipeDeadline) set(t time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.timer != nil && !d.timer.Stop() {
+		<-d.cancel // Wait for the timer callback to finish and close cancel
+	}
+	d.timer = nil
+
+	// Time is zero, then there is no deadline.
+	closed := isClosedChan(d.cancel)
+	if t.IsZero() {
+		if closed {
+			d.cancel = make(chan struct{})
+		}
+		return
+	}
+
+	// Time in the future, setup a timer to cancel in the future.
+	if dur := time.Until(t); dur > 0 {
+		if closed {
+			d.cancel = make(chan struct{})
+		}
+		d.timer = time.AfterFunc(dur, func() {
+			close(d.cancel)
+		})
+		return
+	}
+
+	// Time in the past, so close immediately.
+	if !closed {
+		close(d.cancel)
+	}
+}
+
+// wait returns a channel that is closed when the deadline is exceeded.
+func (d *pipeDeadline) wait() chan struct{} {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.cancel
+}
+
+func isClosedChan(c <-chan struct{}) bool {
+	select {
+	case <-c:
+		return true
+	default:
+		return false
+	}
+}

--- a/mux.go
+++ b/mux.go
@@ -3,6 +3,7 @@ package yamux
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"time"
 )
@@ -69,7 +70,7 @@ func VerifyConfig(config *Config) error {
 // Server is used to initialize a new server-side connection.
 // There must be at most one server-side connection. If a nil config is
 // provided, the DefaultConfiguration will be used.
-func Server(conn io.ReadWriteCloser, config *Config) (*Session, error) {
+func Server(conn net.Conn, config *Config) (*Session, error) {
 	if config == nil {
 		config = DefaultConfig()
 	}
@@ -81,7 +82,7 @@ func Server(conn io.ReadWriteCloser, config *Config) (*Session, error) {
 
 // Client is used to initialize a new client-side connection.
 // There must be at most one client-side connection.
-func Client(conn io.ReadWriteCloser, config *Config) (*Session, error) {
+func Client(conn net.Conn, config *Config) (*Session, error) {
 	if config == nil {
 		config = DefaultConfig()
 	}

--- a/session.go
+++ b/session.go
@@ -375,12 +375,42 @@ func (s *Session) send() {
 	}
 }
 
+var writeBufferPool = sync.Pool{
+	New: func() interface{} {
+		return bufio.NewWriter(nil)
+	},
+}
+
+func getBuffer(w io.Writer) *bufio.Writer {
+	wb := writeBufferPool.Get().(*bufio.Writer)
+	wb.Reset(w)
+	return wb
+}
+
+func returnBuffer(wb *bufio.Writer) {
+	if wb == nil {
+		return
+	}
+	wb.Reset(nil)
+	writeBufferPool.Put(wb)
+}
+
 func (s *Session) sendLoop() error {
 	defer close(s.sendDoneCh)
 
+	var lastWriteDeadline time.Time
 	extendWriteDeadline := func() error {
-		return s.conn.SetWriteDeadline(time.Now().Add(s.config.ConnectionWriteTimeout))
+		now := time.Now()
+		// If over half of the deadline has elapsed, extend it.
+		if now.Add(s.config.ConnectionWriteTimeout / 2).After(lastWriteDeadline) {
+			return s.conn.SetWriteDeadline(now.Add(s.config.ConnectionWriteTimeout))
+		}
+		return nil
 	}
+
+	writer := getBuffer(s.conn)
+	// avoid capturing writer by-value, it changes.
+	defer func() { returnBuffer(writer) }()
 
 	for {
 		// yield after processing the last message, if we've shutdown.
@@ -390,33 +420,47 @@ func (s *Session) sendLoop() error {
 			return nil
 		default:
 		}
+
+		var ready sendReady
 		select {
-		case ready := <-s.sendCh:
-			if err := extendWriteDeadline(); err != nil {
+		case ready = <-s.sendCh:
+		default:
+			if err := writer.Flush(); err != nil {
 				return err
 			}
-			_, err := s.conn.Write(ready.Hdr[:])
+			returnBuffer(writer)
+
+			select {
+			case ready = <-s.sendCh:
+			case <-s.shutdownCh:
+				return nil
+			}
+
+			writer = getBuffer(s.conn)
+		}
+
+		if err := extendWriteDeadline(); err != nil {
+			return err
+		}
+
+		_, err := s.conn.Write(ready.Hdr[:])
+		if err != nil {
+			if isTimeout(err) {
+				err = ErrConnectionWriteTimeout
+			}
+			return err
+		}
+
+		// Send data from a body if given
+		if len(ready.Body) > 0 {
+			_, err := s.conn.Write(ready.Body)
 			if err != nil {
 				if isTimeout(err) {
 					err = ErrConnectionWriteTimeout
 				}
 				return err
 			}
-
-			// Send data from a body if given
-			if len(ready.Body) > 0 {
-				_, err := s.conn.Write(ready.Body)
-				if err != nil {
-					if isTimeout(err) {
-						err = ErrConnectionWriteTimeout
-					}
-					return err
-				}
-			}
-		case <-s.shutdownCh:
-			return nil
 		}
-
 	}
 }
 

--- a/session.go
+++ b/session.go
@@ -473,15 +473,11 @@ func (s *Session) sendLoop() error {
 				continue
 			}
 
-			sent := 0
-			for sent < len(ready.Hdr) {
-				n, err := s.conn.Write(ready.Hdr[sent:])
-				if err != nil {
-					s.logger.Printf("[ERR] yamux: Failed to write header: %v", err)
-					asyncSendErr(ready.Err, err)
-					return err
-				}
-				sent += n
+			_, err := s.conn.Write(ready.Hdr[:])
+			if err != nil {
+				s.logger.Printf("[ERR] yamux: Failed to write header: %v", err)
+				asyncSendErr(ready.Err, err)
+				return err
 			}
 
 			// Send data from a body if given

--- a/session_test.go
+++ b/session_test.go
@@ -1194,7 +1194,7 @@ func TestSession_PartialReadWindowUpdate(t *testing.T) {
 
 	wg.Wait()
 
-	_, err = io.ReadFull(stream, make([]byte, flood/2+1))
+	_, err = io.ReadFull(stream, make([]byte, flood/2))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1202,7 +1202,7 @@ func TestSession_PartialReadWindowUpdate(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 
 	sendWindow := atomic.LoadUint32(&wr.sendWindow)
-	if exp := uint32(flood/2 + 1); sendWindow != exp {
+	if exp := uint32(flood / 2); sendWindow != exp {
 		t.Errorf("sendWindow: exp=%d, got=%d", exp, sendWindow)
 	}
 }

--- a/session_test.go
+++ b/session_test.go
@@ -1239,8 +1239,7 @@ func TestSession_sendNoWait_Timeout(t *testing.T) {
 		conn := client.conn.(*pipeConn)
 		conn.BlockWrites()
 
-		hdr := header(make([]byte, headerSize))
-		hdr.encode(typePing, flagACK, 0, 0)
+		hdr := encode(typePing, flagACK, 0, 0)
 		for {
 			err = client.sendNoWait(hdr)
 			if err == nil {
@@ -1283,8 +1282,7 @@ func TestSession_PingOfDeath(t *testing.T) {
 
 		conn.BlockWrites()
 		for {
-			hdr := header(make([]byte, headerSize))
-			hdr.encode(typePing, 0, 0, 0)
+			hdr := encode(typePing, 0, 0, 0)
 			err = server.sendNoWait(hdr)
 			if err == nil {
 				continue

--- a/session_test.go
+++ b/session_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -32,33 +33,42 @@ func captureLogs(s *Session) *logCapture {
 }
 
 type pipeConn struct {
-	reader       *io.PipeReader
-	writer       *io.PipeWriter
-	writeBlocker chan struct{}
-	closeCh      chan struct{}
+	net.Conn
+	writeDeadline pipeDeadline
+	writeBlocker  chan struct{}
+	closeCh       chan struct{}
 }
 
-func (p *pipeConn) Read(b []byte) (int, error) {
-	return p.reader.Read(b)
+func (p *pipeConn) SetDeadline(t time.Time) error {
+	p.writeDeadline.set(t)
+	return p.Conn.SetDeadline(t)
+}
+
+func (p *pipeConn) SetWriteDeadline(t time.Time) error {
+	p.writeDeadline.set(t)
+	return p.Conn.SetWriteDeadline(t)
 }
 
 func (p *pipeConn) Write(b []byte) (int, error) {
 	select {
 	case p.writeBlocker <- struct{}{}:
+	case <-p.writeDeadline.wait():
+		return 0, ErrTimeout
 	case <-p.closeCh:
 		return 0, io.ErrClosedPipe
 	}
-	n, err := p.writer.Write(b)
+	n, err := p.Conn.Write(b)
 	<-p.writeBlocker
 	return n, err
 }
 
 func (p *pipeConn) Close() error {
-	p.reader.Close()
-	werr := p.writer.Close()
+	p.writeDeadline.set(time.Time{})
+	err := p.Conn.Close()
 	close(p.closeCh)
-	return werr
+	return err
 }
+
 func (p *pipeConn) BlockWrites() {
 	p.writeBlocker <- struct{}{}
 }
@@ -67,20 +77,19 @@ func (p *pipeConn) UnblockWrites() {
 	<-p.writeBlocker
 }
 
-func testConn() (io.ReadWriteCloser, io.ReadWriteCloser) {
-	read1, write1 := io.Pipe()
-	read2, write2 := io.Pipe()
-	conn1 := &pipeConn{
-		reader:       read1,
-		writer:       write2,
-		writeBlocker: make(chan struct{}, 1),
-		closeCh:      make(chan struct{}, 1),
+func testConn() (conn1, conn2 net.Conn) {
+	c1, c2 := net.Pipe()
+	conn1 = &pipeConn{
+		Conn:          c1,
+		writeDeadline: makePipeDeadline(),
+		writeBlocker:  make(chan struct{}, 1),
+		closeCh:       make(chan struct{}, 1),
 	}
-	conn2 := &pipeConn{
-		reader:       read2,
-		writer:       write1,
-		writeBlocker: make(chan struct{}, 1),
-		closeCh:      make(chan struct{}, 1),
+	conn2 = &pipeConn{
+		Conn:          c2,
+		writeDeadline: makePipeDeadline(),
+		writeBlocker:  make(chan struct{}, 1),
+		closeCh:       make(chan struct{}, 1),
 	}
 	return conn1, conn2
 }
@@ -222,48 +231,6 @@ func TestPing(t *testing.T) {
 	}
 	if rtt == 0 {
 		t.Fatalf("bad: %v", rtt)
-	}
-}
-
-func TestPing_Timeout(t *testing.T) {
-	client, server := testClientServerConfig(testConfNoKeepAlive())
-	defer client.Close()
-	defer server.Close()
-
-	// Prevent the client from responding
-	clientConn := client.conn.(*pipeConn)
-	clientConn.BlockWrites()
-
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := server.Ping() // Ping via the server session
-		errCh <- err
-	}()
-
-	select {
-	case err := <-errCh:
-		if err != ErrTimeout {
-			t.Fatalf("err: %v", err)
-		}
-	case <-time.After(client.config.ConnectionWriteTimeout * 2):
-		t.Fatalf("failed to timeout within expected %v", client.config.ConnectionWriteTimeout)
-	}
-
-	// Verify that we recover, even if we gave up
-	clientConn.UnblockWrites()
-
-	go func() {
-		_, err := server.Ping() // Ping via the server session
-		errCh <- err
-	}()
-
-	select {
-	case err := <-errCh:
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	case <-time.After(client.config.ConnectionWriteTimeout):
-		t.Fatalf("timeout")
 	}
 }
 
@@ -443,6 +410,10 @@ func TestSendData_Small(t *testing.T) {
 		if err := stream.Close(); err != nil {
 			t.Fatalf("err: %v", err)
 		}
+		n, err := stream.Read([]byte{0})
+		if n != 0 || err != io.EOF {
+			t.Errorf("err: %v", err)
+		}
 	}()
 
 	go func() {
@@ -468,6 +439,10 @@ func TestSendData_Small(t *testing.T) {
 
 		if err := stream.Close(); err != nil {
 			t.Fatalf("err: %v", err)
+		}
+		n, err := stream.Read([]byte{0})
+		if n != 0 || err != io.EOF {
+			t.Errorf("err: %v", err)
 		}
 	}()
 
@@ -517,7 +492,7 @@ func TestSendData_Large(t *testing.T) {
 		var sz int
 		buf := make([]byte, recvSize)
 		for i := 0; i < sendSize/recvSize; i++ {
-			n, err := stream.Read(buf)
+			n, err := io.ReadFull(stream, buf)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -580,10 +555,18 @@ func TestGoAway(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	_, err := client.Open()
-	if err != ErrRemoteGoAway {
-		t.Fatalf("err: %v", err)
+	for i := 0; i < 100; i++ {
+		s, err := client.Open()
+		switch err {
+		case nil:
+			s.Close()
+		case ErrRemoteGoAway:
+			return
+		default:
+			t.Fatalf("err: %v", err)
+		}
 	}
+	t.Fatalf("expected GoAway error")
 }
 
 func TestManyStreams(t *testing.T) {
@@ -665,7 +648,7 @@ func TestManyStreams_PingPong(t *testing.T) {
 		buf := make([]byte, 4)
 		for {
 			// Read the 'ping'
-			n, err := stream.Read(buf)
+			n, err := io.ReadFull(stream, buf)
 			if err == io.EOF {
 				return
 			}
@@ -712,7 +695,7 @@ func TestManyStreams_PingPong(t *testing.T) {
 			}
 
 			// Read the 'pong'
-			n, err = stream.Read(buf)
+			n, err = io.ReadFull(stream, buf)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -1015,7 +998,7 @@ func TestSendData_VeryLarge(t *testing.T) {
 			defer stream.Close()
 
 			buf := make([]byte, 4)
-			_, err = stream.Read(buf)
+			_, err = io.ReadFull(stream, buf)
 			if err != nil {
 				t.Fatalf("err: %v", err)
 			}
@@ -1108,7 +1091,9 @@ func TestSession_WindowUpdateWriteDuringRead(t *testing.T) {
 	wg.Add(2)
 
 	// Choose a huge flood size that we know will result in a window update.
-	flood := int64(client.config.MaxStreamWindowSize) - 1
+	flood := int64(client.config.MaxStreamWindowSize) + 1
+
+	sync := make(chan struct{})
 
 	// The server will accept a new stream and then flood data to it.
 	go func() {
@@ -1116,16 +1101,19 @@ func TestSession_WindowUpdateWriteDuringRead(t *testing.T) {
 
 		stream, err := server.AcceptStream()
 		if err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
+			server.Close()
+			return
 		}
 		defer stream.Close()
 
-		n, err := stream.Write(make([]byte, flood))
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		if int64(n) != flood {
-			t.Fatalf("short write: %d", n)
+		<-sync
+		sync <- struct{}{}
+
+		_, err = stream.Write(make([]byte, flood))
+		if err == nil {
+			t.Errorf("expected write to fail due to no window update")
+			return
 		}
 	}()
 
@@ -1137,16 +1125,20 @@ func TestSession_WindowUpdateWriteDuringRead(t *testing.T) {
 
 		stream, err := client.OpenStream()
 		if err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
+			server.Close()
+			return
 		}
 		defer stream.Close()
 
+		sync <- struct{}{}
 		conn := client.conn.(*pipeConn)
 		conn.BlockWrites()
+		<-sync
 
-		_, err = stream.Read(make([]byte, flood))
-		if err != ErrConnectionWriteTimeout {
-			t.Fatalf("err: %v", err)
+		_, err = io.ReadFull(stream, make([]byte, flood))
+		if err == nil {
+			t.Errorf("expected read to fail")
 		}
 	}()
 
@@ -1176,8 +1168,9 @@ func TestSession_PartialReadWindowUpdate(t *testing.T) {
 		}
 		defer wr.Close()
 
-		if wr.sendWindow != client.config.MaxStreamWindowSize {
-			t.Fatalf("sendWindow: exp=%d, got=%d", client.config.MaxStreamWindowSize, wr.sendWindow)
+		sendWindow := atomic.LoadUint32(&wr.sendWindow)
+		if sendWindow != client.config.MaxStreamWindowSize {
+			t.Fatalf("sendWindow: exp=%d, got=%d", client.config.MaxStreamWindowSize, sendWindow)
 		}
 
 		n, err := wr.Write(make([]byte, flood))
@@ -1187,8 +1180,9 @@ func TestSession_PartialReadWindowUpdate(t *testing.T) {
 		if int64(n) != flood {
 			t.Fatalf("short write: %d", n)
 		}
-		if wr.sendWindow != 0 {
-			t.Fatalf("sendWindow: exp=%d, got=%d", 0, wr.sendWindow)
+		sendWindow = atomic.LoadUint32(&wr.sendWindow)
+		if sendWindow != 0 {
+			t.Fatalf("sendWindow: exp=%d, got=%d", 0, sendWindow)
 		}
 	}()
 
@@ -1200,59 +1194,38 @@ func TestSession_PartialReadWindowUpdate(t *testing.T) {
 
 	wg.Wait()
 
-	_, err = stream.Read(make([]byte, flood/2+1))
+	_, err = io.ReadFull(stream, make([]byte, flood/2+1))
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	if exp := uint32(flood/2 + 1); wr.sendWindow != exp {
-		t.Errorf("sendWindow: exp=%d, got=%d", exp, wr.sendWindow)
+	time.Sleep(1 * time.Millisecond)
+
+	sendWindow := atomic.LoadUint32(&wr.sendWindow)
+	if exp := uint32(flood/2 + 1); sendWindow != exp {
+		t.Errorf("sendWindow: exp=%d, got=%d", exp, sendWindow)
 	}
 }
 
-func TestSession_sendNoWait_Timeout(t *testing.T) {
+func TestSession_sendMsg_Timeout(t *testing.T) {
 	client, server := testClientServerConfig(testConfNoKeepAlive())
 	defer client.Close()
 	defer server.Close()
 
-	var wg sync.WaitGroup
-	wg.Add(2)
+	conn := client.conn.(*pipeConn)
+	conn.BlockWrites()
 
-	go func() {
-		defer wg.Done()
-
-		stream, err := server.AcceptStream()
-		if err != nil {
+	hdr := encode(typePing, flagACK, 0, 0)
+	for {
+		err := client.sendMsg(hdr, nil, nil)
+		if err == nil {
+			continue
+		} else if err == ErrConnectionWriteTimeout {
+			break
+		} else {
 			t.Fatalf("err: %v", err)
 		}
-		defer stream.Close()
-	}()
-
-	// The client will open the stream and then block outbound writes, we'll
-	// probe sendNoWait once it gets into that state.
-	go func() {
-		defer wg.Done()
-
-		stream, err := client.OpenStream()
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		defer stream.Close()
-
-		conn := client.conn.(*pipeConn)
-		conn.BlockWrites()
-
-		hdr := encode(typePing, flagACK, 0, 0)
-		for {
-			err = client.sendNoWait(hdr)
-			if err == nil {
-				continue
-			} else if err == ErrConnectionWriteTimeout {
-				break
-			} else {
-				t.Fatalf("err: %v", err)
-			}
-		}
-	}()
-
-	wg.Wait()
+	}
 }
 
 func TestSession_PingOfDeath(t *testing.T) {
@@ -1261,67 +1234,25 @@ func TestSession_PingOfDeath(t *testing.T) {
 	defer server.Close()
 
 	var wg sync.WaitGroup
-	wg.Add(2)
-
-	var doPingOfDeath sync.Mutex
-	doPingOfDeath.Lock()
-
-	// This is used later to block outbound writes.
-	conn := server.conn.(*pipeConn)
-
-	// The server will accept a stream, block outbound writes, and then
-	// flood its send channel so that no more headers can be queued.
-	go func() {
-		defer wg.Done()
-
-		stream, err := server.AcceptStream()
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		defer stream.Close()
-
-		conn.BlockWrites()
-		for {
-			hdr := encode(typePing, 0, 0, 0)
-			err = server.sendNoWait(hdr)
-			if err == nil {
-				continue
-			} else if err == ErrConnectionWriteTimeout {
-				break
-			} else {
-				t.Fatalf("err: %v", err)
+	begin := make(chan struct{})
+	for i := 0; i < 10000; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-begin
+			if _, err := server.Ping(); err != nil {
+				t.Error(err)
 			}
-		}
-
-		doPingOfDeath.Unlock()
-	}()
-
-	// The client will open a stream and then send the server a ping once it
-	// can no longer write. This makes sure the server doesn't deadlock reads
-	// while trying to reply to the ping with no ability to write.
-	go func() {
-		defer wg.Done()
-
-		stream, err := client.OpenStream()
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		defer stream.Close()
-
-		// This ping will never unblock because the ping id will never
-		// show up in a response.
-		doPingOfDeath.Lock()
-		go func() { client.Ping() }()
-
-		// Wait for a while to make sure the previous ping times out,
-		// then turn writes back on and make sure a ping works again.
-		time.Sleep(2 * server.config.ConnectionWriteTimeout)
-		conn.UnblockWrites()
-		if _, err = client.Ping(); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}()
-
+		}()
+		go func() {
+			defer wg.Done()
+			<-begin
+			if _, err := client.Ping(); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	close(begin)
 	wg.Wait()
 }
 
@@ -1333,6 +1264,8 @@ func TestSession_ConnectionWriteTimeout(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
+	sync := make(chan struct{})
+
 	go func() {
 		defer wg.Done()
 
@@ -1340,6 +1273,10 @@ func TestSession_ConnectionWriteTimeout(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
+
+		<-sync
+		sync <- struct{}{}
+
 		defer stream.Close()
 	}()
 
@@ -1354,18 +1291,21 @@ func TestSession_ConnectionWriteTimeout(t *testing.T) {
 		}
 		defer stream.Close()
 
+		sync <- struct{}{}
 		conn := client.conn.(*pipeConn)
 		conn.BlockWrites()
+		<-sync
 
-		// Since the write goroutine is blocked then this will return a
-		// timeout since it can't get feedback about whether the write
-		// worked.
-		n, err := stream.Write([]byte("hello"))
-		if err != ErrConnectionWriteTimeout {
-			t.Fatalf("err: %v", err)
-		}
-		if n != 0 {
-			t.Fatalf("lied about writes: %d", n)
+		// Fill up the write queue and wait for the write to timeout.
+		for {
+			_, err := stream.Write([]byte("hello"))
+			if err == nil {
+				continue
+			} else if err == ErrConnectionWriteTimeout {
+				break
+			} else {
+				t.Fatalf("err: %v", err)
+			}
 		}
 	}()
 
@@ -1494,15 +1434,20 @@ func TestLotsOfWritesWithStreamDeadline(t *testing.T) {
 
 	// Server side accepts two streams. The first one is the clogger.
 	go func() {
+		defer close(doneCh)
 		_, err := server.AcceptStream()
 		if err != nil {
 			t.Error(err)
+			return
 		}
 
 		stream2, err := server.AcceptStream()
 		if err != nil {
 			t.Error(err)
+			return
 		}
+
+		waitCh <- struct{}{}
 
 		// Wait until all writes have timed out on the client.
 		<-waitCh
@@ -1511,21 +1456,25 @@ func TestLotsOfWritesWithStreamDeadline(t *testing.T) {
 		stream2.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
 		if b, err := ioutil.ReadAll(stream2); len(b) != 0 || err != ErrTimeout {
 			t.Errorf("writes from the client should've expired; got: %v, bytes: %v", err, b)
+			return
 		}
-		doneCh <- struct{}{}
 	}()
 
 	// stream1 is the clogger.
 	stream1, err := client.OpenStream()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	// all writes on stream2 will time out.
 	stream2, err := client.OpenStream()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
+	defer stream2.Reset()
+
+	// wait for the server to accept the streams.
+	<-waitCh
 
 	clientConn := client.conn.(*pipeConn)
 	clientConn.BlockWrites()
@@ -1536,106 +1485,76 @@ func TestLotsOfWritesWithStreamDeadline(t *testing.T) {
 		stream1.Write([]byte{100})
 	}()
 
-	time.Sleep(300 * time.Millisecond)
-
-	// Send 100 writes on stream2.
+	// Keep writing till we fill the buffer and timeout.
 	var wg sync.WaitGroup
-	wg.Add(100)
-	for i := 0; i < 100; i++ {
-		go func(i int) {
-			defer wg.Done()
-			stream2.SetWriteDeadline(time.Now().Add(100 * time.Millisecond))
-			n, err := stream2.Write([]byte{byte(i)})
-
-			if err != ErrTimeout || n != 0 {
-				t.Errorf("expected stream timeout error, got: %v, n: %d", err, n)
-			}
-		}(i)
+	stream2.SetWriteDeadline(time.Now().Add(100 * time.Millisecond))
+	for {
+		_, err := stream2.Write([]byte("foobar"))
+		if err == nil {
+			continue
+		} else if err == ErrTimeout {
+			break
+		} else {
+			t.Errorf("expected stream timeout error, got: %v", err)
+			break
+		}
 	}
 
 	// All writes completed and timed out; notify the server.
 	wg.Wait()
-	waitCh <- struct{}{}
-
+	select {
+	case waitCh <- struct{}{}:
+	default:
+	}
 	<-doneCh
 }
 
-func TestConnTimeoutPartialWriteClosesConnection(t *testing.T) {
-	config := testConf()
-	// 8mb; we want the yamux window size to be big so that we're stalled by TCP's congestion control, not by yamux
-	// thus causing a connection timeout
-	config.MaxStreamWindowSize = 8 * 1024 * 1024
-	config.ConnectionWriteTimeout = 1 * time.Second
-	config.EnableKeepAlive = false
+func TestReadDeadlineInterrupt(t *testing.T) {
+	client, server := testClientServer()
+	defer client.Close()
+	defer server.Close()
 
-	l, err := net.ListenTCP("tcp", nil)
+	stream, err := client.Open()
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("err: %v", err)
 	}
-	defer l.Close()
+	defer stream.Close()
 
-	bufferSetCh := make(chan struct{})
+	stream2, err := server.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer stream2.Close()
 
-	// Server-side: a socket that reads 100 bytes, and then stalls, i.e. perceived as a partial write from the sender.
+	done := make(chan struct{})
 	go func() {
-		conn, err := l.AcceptTCP()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err = conn.SetReadBuffer(1); err != nil {
-			t.Fatal(err)
-		}
-
-		bufferSetCh <- struct{}{}
-
-		buf := make([]byte, 100)
-		total := 0
-		for total < 100 {
-			if n, err := conn.Read(buf); err != nil {
-				t.Errorf("expected to read to not fail, err: %v", err)
-			} else {
-				total += n
-			}
+		defer close(done)
+		buf := make([]byte, 4)
+		if _, err := stream.Read(buf); err != ErrTimeout {
+			t.Fatalf("err: %v", err)
 		}
 	}()
 
-	var addr *net.TCPAddr
-	var conn *net.TCPConn
-	var sess *Session
-	var s *Stream
-
-	// Client-side: set a tiny write buffer to force the application (yamux) to wait.
-	if addr, err = net.ResolveTCPAddr("tcp", l.Addr().String()); err != nil {
-		t.Fatal(err)
-	}
-	if conn, err = net.DialTCP("tcp", nil, addr); err != nil {
-		t.Fatal(err)
-	}
-	if err = conn.SetWriteBuffer(1); err != nil {
-		t.Fatal(err)
+	select {
+	case <-done:
+		t.Fatal("read shouldn't have finished")
+	case <-time.After(5 * time.Millisecond):
 	}
 
-	<-bufferSetCh
+	if err := stream.SetReadDeadline(time.Now().Add(5 * time.Millisecond)); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-	if sess, err = Client(conn, config); err != nil {
-		t.Fatal(err)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Millisecond):
+		t.Fatal("read should have finished")
 	}
-	if s, err = sess.OpenStream(); err != nil {
-		t.Fatal(err)
-	}
-	if s.Session().IsClosed() {
-		t.Error("expected session to be open")
-	}
-	if n, err := s.Write(make([]byte, 1024*1024)); err == nil || !strings.Contains(err.Error(), "timeout") {
-		t.Errorf("expected write to timeout, written bytes: %d, err: %v", n, err)
-	}
-	if !s.Session().IsClosed() {
-		t.Error("expected session to be closed following the timeout")
-	}
-	if s.state != streamReset {
-		t.Error("expected session state to be 'streamReset'")
-	}
-	if err := s.Reset(); err != nil {
-		t.Error("expected stream reset to be noop")
+
+	for i := 0; i < 5; i++ {
+		buf := make([]byte, 4)
+		if _, err := stream.Read(buf); err != ErrTimeout {
+			t.Fatalf("err: %v", err)
+		}
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -164,8 +164,8 @@ START:
 	// Determine the flags if any
 	flags = s.sendFlags()
 
-	// Send up to our send window
-	max = min(window, uint32(len(b)))
+	// Send up to min(message, window
+	max = min(window, maxMessageSize, uint32(len(b)))
 
 	// Send the header
 	hdr = encode(typeData, flags, s.id, max)

--- a/stream.go
+++ b/stream.go
@@ -166,7 +166,6 @@ func (s *Stream) Write(b []byte) (n int, err error) {
 func (s *Stream) write(b []byte, timeout <-chan time.Time) (n int, err error) {
 	var flags uint16
 	var max uint32
-	var body io.Reader
 	var hdr header
 
 START:
@@ -194,11 +193,10 @@ START:
 
 	// Send up to our send window
 	max = min(window, uint32(len(b)))
-	body = bytes.NewReader(b[:max])
 
 	// Send the header
 	hdr = encode(typeData, flags, s.id, max)
-	if err = s.session.waitForSendErr(hdr, body, s.sendErr, timeout); err != nil {
+	if err = s.session.waitForSendErr(hdr, b[:max], s.sendErr, timeout); err != nil {
 		return 0, err
 	}
 

--- a/util.go
+++ b/util.go
@@ -34,12 +34,15 @@ func asyncNotify(ch chan struct{}) {
 	}
 }
 
-// min computes the minimum of two values
-func min(a, b uint32) uint32 {
-	if a < b {
-		return a
+// min computes the minimum of a set of values
+func min(values ...uint32) uint32 {
+	m := values[0]
+	for _, v := range values[1:] {
+		if v < m {
+			m = v
+		}
 	}
-	return b
+	return m
 }
 
 func isTimeout(err error) bool {

--- a/util.go
+++ b/util.go
@@ -41,3 +41,8 @@ func min(a, b uint32) uint32 {
 	}
 	return b
 }
+
+func isTimeout(err error) bool {
+	terr, ok := err.(interface{ Timeout() bool })
+	return ok && terr.Timeout()
+}


### PR DESCRIPTION
(sorry for the monster PR, these changes turned into a bit of a rabbit hole)

First up, this patch correctly implements deadlines:

1. Deadlines now apply to in-progress operations, allowing us to cancel writes/reads with deadlines. I need this to correctly implement `Close()` in the circuit transport.
2. The ConnectionWriteTimeout now actually does what it says it does: When we fail to write fast enough, it kills the entire connection.
3. _All_ writes are now async.
   a. We can't abort after a partial write anyways but we shouldn't block the stream write until we finish writing to the underlying connection. The simple solution is to claim that the write succeeds when we enqueue it. This is fine as network writes are buffered anyways.
   b. The network is buffered so it doesn't matter.
   c. We need this to coalesce/buffer writes to reduce packet count/secio overhead.

Next, this PR coalesces writes from any number of streams.

Finally, this PR breaks large writes into 16KiB chunks to:

1. Ensure fairness between streams.
2. Ensure that one large write doesn't block the send loop and make us think we've timed out.

Breaking:

* Probably changes a few errors.
* Requires `net.Conn` (for deadlines). Shouldn't break _our_ code as our stream muxer interfaces use `net.Conn` anyways.
* Anything expecting writes to be synchronous will break. That is, nothing that actually uses the network.